### PR TITLE
Update lupload to work in python3

### DIFF
--- a/src/lambda_setuptools/lupload.py
+++ b/src/lambda_setuptools/lupload.py
@@ -54,7 +54,7 @@ class LUpload(Command):
             getattr(self, 's3_bucket'),
             getattr(self, 'kms_key_id')
         ))
-        with open(dist_path) as dist:
+        with open(dist_path, 'rb') as dist:
             if getattr(self, 'kms_key_id'):
                 response = s3.put_object(
                     Body=dist,


### PR DESCRIPTION
Tried using this project in python3.6 but it failed on s3.put_object requiring a byte stream rather than a string stream. Easily fixed by explicitly opening the file (compressed) in byte mode!