### PR TITLE
Set access-key/secret-access-key defaults from environ.

### DIFF
--- a/src/lambda_setuptools/lupload.py
+++ b/src/lambda_setuptools/lupload.py
@@ -1,5 +1,6 @@
 import boto3
 import json
+import os
 
 from botocore.client import Config
 from distutils import log
@@ -22,10 +23,10 @@ class LUpload(Command):
     def initialize_options(self):
         """Set default values for options."""
         # Each user option must be listed here with their default value.
-        setattr(self, 'access_key', None)
+        setattr(self, 'access_key', os.environ.get('AWS_ACCESS_KEY_ID', None))
         setattr(self, 'kms_key_id', None)
         setattr(self, 's3_prefix', '')
-        setattr(self, 'secret_access_key', None)
+        setattr(self, 'secret_access_key', os.environ.get('AWS_SECRET_ACCESS_KEY', None))
         setattr(self, 's3_bucket', None)
         setattr(self, 'endpoint_url', '')
 


### PR DESCRIPTION
AWS CLI loads access-key/secret-access-key from environment variables
AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY if they present. So we could do
the same as well as these environment variables are common in CI/CD
machines.

By loading keys from environment variables instead of from command line
options, we could **hide** the keys in CI/CD job outputs. So the keys
are not that easy to leak.