### PR TITLE
AWS region from env

### DIFF
--- a/src/lambda_setuptools/lupdate.py
+++ b/src/lambda_setuptools/lupdate.py
@@ -20,7 +20,7 @@ class LUpdate(Command):
         """Set default values for options."""
         # Each user option must be listed here with their default value.
         setattr(self, 'function_names', None)
-        setattr(self, 'region', os.environ.get('AWS_DEFAULT_REGION', 'us-east-1'))
+        setattr(self, 'region', os.environ.get('AWS_REGION', os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')))
 
     def finalize_options(self):
         """Post-process options."""

--- a/src/lambda_setuptools/lupdate.py
+++ b/src/lambda_setuptools/lupdate.py
@@ -1,5 +1,6 @@
 import boto3
 import json
+import os
 
 from botocore.client import Config
 from botocore.exceptions import ClientError
@@ -19,7 +20,7 @@ class LUpdate(Command):
         """Set default values for options."""
         # Each user option must be listed here with their default value.
         setattr(self, 'function_names', None)
-        setattr(self, 'region', 'us-east-1')
+        setattr(self, 'region', os.environ.get('AWS_DEFAULT_REGION', 'us-east-1'))
 
     def finalize_options(self):
         """Post-process options."""


### PR DESCRIPTION
Repect `AWS_REGION`, `AWS_DEFAULT_REGION` environment variables.

If `--region` is not specified when running `lupdate` command, try load region from `AWS_REGION` environment variable first (just like how `aws-cli` do), then `AWS_DEFAULT_REGION` next. Only fall back to `us-east-1` if no such environment variable found.