### PR TITLE
Allow no S3 object versions

### DIFF
--- a/src/lambda_setuptools/lupdate.py
+++ b/src/lambda_setuptools/lupdate.py
@@ -33,7 +33,9 @@ class LUpdate(Command):
         s3_bucket = getattr(lupload_cmd, 's3_bucket')
         s3_key = getattr(lupload_cmd, 's3_object_key')
         s3_object_version = getattr(lupload_cmd, 's3_object_version')
-        if s3_bucket is None or s3_key is None or s3_object_version is None:
+        # s3_object_version could be None if Versioning is not enabled in that
+        # bucket. That will be okay as it is optional to update_function_code.
+        if s3_bucket is None or s3_key is None:
             raise DistutilsArgError('\'lupload\' missing attributes')
         aws_lambda = boto3.client(
             'lambda',

--- a/src/lambda_setuptools/lupdate.py
+++ b/src/lambda_setuptools/lupdate.py
@@ -47,12 +47,14 @@ class LUpdate(Command):
         for function_name in getattr(self, 'function_names').split(','):
             try:
                 log.info('Updating and publishing {}'.format(function_name))
-                aws_lambda.update_function_code(
+                kwargs = dict(
                     FunctionName=function_name,
                     S3Bucket=s3_bucket,
                     S3Key=s3_key,
-                    S3ObjectVersion=s3_object_version,
                     Publish=True
                 )
+                if s3_object_version:
+                    kwargs['S3ObjectVersion'] = s3_object_version
+                aws_lambda.update_function_code(**kwargs)
             except ClientError as err:
                 log.warn('Error updating {}\n{}'.format(function_name, err))

--- a/src/lambda_setuptools/lupload.py
+++ b/src/lambda_setuptools/lupload.py
@@ -83,7 +83,7 @@ class LUpload(Command):
                     ServerSideEncryption='AES256'
                 )
         setattr(self, 's3_object_key', dist_name)
-        setattr(self, 's3_object_version', response['VersionId'])
+        setattr(self, 's3_object_version', response.get('VersionId'))
         log.info('upload complete:\n{}'.format(
             json.dumps(response, sort_keys=True, indent=4, separators=(',', ': ')))
         )


### PR DESCRIPTION
If versioning is not enabled in the bucket, after put object there will be no version id. In this case, do not raise error and continue.

When update lambda function, if `s3_object_version` is None, continue to invoke `update_function_code()` without s3 object version. That would be okay as it is optional.